### PR TITLE
Make outputDir customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ You can customise what is downloaded with the following:
 - `platform` - the platform you want to download. Choices are `darwin`, `win32`, `linux`. This defaults to the host platform.
 - `arch` - the architecture of the platform you want to download. This defaults to the host architecture.
 - `cacheDir` - the location of the caching directory in which downloads will be stored. This defaults to `./electron/cache`.
-- `outputDir` - the location of the unzipped binaries. This defaults to `./electron/binaries`. The platform is always appended to this path.
+- `outputDir` - the location of the unzipped binaries. This defaults to `./electron/binaries`. The platform+arch is always appended to this path like so: `linux32`, `linux64`, `win32`, `win64`, `darwin64`.

--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ You can customise what is downloaded with the following:
 - `platform` - the platform you want to download. Choices are `darwin`, `win32`, `linux`. This defaults to the host platform.
 - `arch` - the architecture of the platform you want to download. This defaults to the host architecture.
 - `cacheDir` - the location of the caching directory in which downloads will be stored. This defaults to `./electron/cache`.
-- `outputDir` - the location of the unzipped binaries. This defaults to `./electron/binaries`. The platform+arch is always appended to this path like so: `linux32`, `linux64`, `win32`, `win64`, `darwin64`.
+- `outputDir` - the location of the unzipped binary. This defaults to `./electron/binaries/platform-arch/`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-electron-downloader",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A gulp.js plugin to help download electron.",
   "main": "plugin.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-electron-downloader",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "A gulp.js plugin to help download electron.",
   "main": "plugin.js",
   "scripts": {

--- a/plugin.js
+++ b/plugin.js
@@ -226,7 +226,16 @@ module.exports = function (options, callback) {
 
         function (cb) {
 
-            options.private.outputDir = path.resolve(path.join(options.outputDir, options.platform));
+            var outputName = {
+              'darwin': 'darwin',
+              'linux': 'linux',
+              'win32': 'win'
+            }[options.platform] + {
+              'ia32': '32',
+              'x64': '64'
+            }[options.arch];
+
+            options.private.outputDir = path.resolve(path.join(options.outputDir, outputName));
 
             // make sure the output directory exists first
             jetpack.dirAsync(options.private.outputDir, {

--- a/plugin.js
+++ b/plugin.js
@@ -43,7 +43,7 @@ function optionDefaults (options, callback) {
     // setup the cache directory
     options.cacheDir = options.cacheDir || './electron/cache';
 
-    // seutp the build dir
+    // setup the build dir
     options.outputDir = options.outputDir || './electron/binaries';
 
     if (options.version) {
@@ -226,16 +226,11 @@ module.exports = function (options, callback) {
 
         function (cb) {
 
-            var outputName = {
-              'darwin': 'darwin',
-              'linux': 'linux',
-              'win32': 'win'
-            }[options.platform] + {
-              'ia32': '32',
-              'x64': '64'
-            }[options.arch];
-
-            options.private.outputDir = path.resolve(path.join(options.outputDir, outputName));
+            if (options.outputDir === './electron/binaries') {
+              options.private.outputDir = path.resolve(path.join(options.outputDir, options.platform + '-' + options.arch));
+            } else {
+              options.private.outputDir = path.resolve(options.outputDir);
+            }
 
             // make sure the output directory exists first
             jetpack.dirAsync(options.private.outputDir, {


### PR DESCRIPTION
I've set up a few tasks that look like so: `electron:download:win32`, `electron:download:linux32`, `electron:download:linux64`. I need to be able to set the outputDir myself, not to mention that the Linux binaries would overwrite each other.
