### PR TITLE
add download mirror support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/smebberson/gulp-electron-downloader",
   "dependencies": {
     "async": "^0.9.0",
-    "extract-zip": "^1.0.3",
+    "extract-zip": "^1.1.1",
     "fs-jetpack": "^0.6.4",
     "gulp-util": "^3.0.4",
     "progress": "^1.1.8",

--- a/plugin.js
+++ b/plugin.js
@@ -52,6 +52,10 @@ function optionDefaults (options, callback) {
         gutil.log('Retrieving latest release');
     }
 
+    if (options.downloadMirror) {
+        gutil.log('Using requested download mirror: ' + options.downloadMirror);
+    }
+
     // download the releases information to retrieve the download URL
     request.get({
         url: 'https://api.github.com/repos/atom/electron/releases',
@@ -95,7 +99,9 @@ function optionDefaults (options, callback) {
 
                         bRelease = true;
                         options.private.downloadUrl = asset.browser_download_url;
-
+                        if (options.downloadMirror) {
+                            options.private.downloadUrl.replace('https://github.com/atom/electron/releases', options.downloadMirror);
+                        }
                     }
 
                 });


### PR DESCRIPTION
add download mirror option into the plugin.
i. e. in china, we can use a mirror like this:

``` coffee
gulp = require 'gulp'
electronDownloader = require 'gulp-electron-downloader'

gulp.task 'download-electron', (cb) ->
  electronDownloader {
    downloadMirror: 'https://npm.taobao.org/mirrors/electron'
  }, cb
```
